### PR TITLE
Updated condition in getCurrentLeverageBps() to allow leverageBps >= 100%

### DIFF
--- a/contracts/vaults/dloop/core/DLoopCoreBase.sol
+++ b/contracts/vaults/dloop/core/DLoopCoreBase.sol
@@ -1691,7 +1691,7 @@ abstract contract DLoopCoreBase is
         uint256 leverageBps = ((totalCollateralBase *
             BasisPointConstants.ONE_HUNDRED_PERCENT_BPS) /
             (totalCollateralBase - totalDebtBase));
-        if (leverageBps <= BasisPointConstants.ONE_HUNDRED_PERCENT_BPS) {
+        if (leverageBps < BasisPointConstants.ONE_HUNDRED_PERCENT_BPS) {
             revert InvalidLeverage(leverageBps);
         }
         return leverageBps;


### PR DESCRIPTION
# Overview

- Discussion: https://stably-team.slack.com/archives/C06LK2MHNFN/p1749898196116569?thread_ts=1749890987.271089&cid=C06LK2MHNFN
- Fixed: 
  - https://github.com/hats-finance/dTRINITY-0xee5c6f15e8d0b55a5eff84bb66beeee0e6140ffe/issues/235
  - https://github.com/hats-finance/dTRINITY-0xee5c6f15e8d0b55a5eff84bb66beeee0e6140ffe/issues/113