### PR TITLE
dLOOP counts all collateral, allowing DoS from supplying another asset

### DIFF
--- a/test/dloop/DLoopCoreMock/foreign-collateral-supply-test.ts
+++ b/test/dloop/DLoopCoreMock/foreign-collateral-supply-test.ts
@@ -1,0 +1,92 @@
+import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import { expect } from "chai";
+import { ethers } from "hardhat";
+
+import { DLoopCoreMock, TestMintableERC20 } from "../../../typechain-types";
+import { deployDLoopMockFixture, testSetup } from "./fixture";
+
+/*
+ * Test reproduces the "Total Assets Manipulation" attack described in the
+ * audit report.  An attacker supplies a **different** token to the lending
+ * pool on behalf of the vault.  Because `totalAssets()` aggregates all
+ * collateral returned by the pool, the vault now believes it owns more of the
+ * designated collateral token than it actually does.  This drives the
+ * leverage calculation out-of-bounds and permanently blocks deposits /
+ * withdrawals for honest users.
+ */
+
+describe("DLoopCoreMock – Foreign‐collateral manipulation", function () {
+  let dloop: DLoopCoreMock;
+  let collateral: TestMintableERC20; // designated vault collateral (mCOLL)
+  let debt: TestMintableERC20; // foreign token we will inject as fake collateral
+  let attacker: HardhatEthersSigner;
+  let victim: HardhatEthersSigner;
+  let fixtureReady = false;
+
+  async function setupFixture() {
+    const fx = await loadFixture(deployDLoopMockFixture);
+    await testSetup(fx);
+
+    dloop = fx.dloopMock;
+    collateral = fx.collateralToken;
+    debt = fx.debtToken;
+    attacker = fx.accounts[1];
+    victim = fx.accounts[2];
+
+    fixtureReady = true;
+  }
+
+  beforeEach(async function () {
+    if (!fixtureReady) {
+      await setupFixture();
+    }
+  });
+
+  it("Attacker inflates totalAssets with foreign collateral and freezes the vault", async function () {
+    const vaultAddr = await dloop.getAddress();
+
+    /* STEP 1 – Honest user deposits legitimate collateral */
+    const victimDeposit = ethers.parseEther("1000");
+    await dloop.connect(victim).deposit(victimDeposit, victim.address);
+
+    const totalAssetsBefore = await dloop.totalAssets();
+    expect(totalAssetsBefore).to.equal(victimDeposit);
+
+    /* STEP 2 – Attacker donates debt-token to the vault and supplies it to the pool
+     * on behalf of the vault, thereby making it look like extra collateral. */
+    const injectedAmount = ethers.parseEther("5000");
+
+    // Ensure attacker controls enough debt tokens
+    await debt.connect(attacker).transfer(vaultAddr, injectedAmount);
+
+    // Supply the foreign collateral to the mock pool on behalf of the vault.
+    await dloop
+      .connect(attacker)
+      .testSupplyToPoolImplementation(
+        await debt.getAddress(),
+        injectedAmount,
+        vaultAddr
+      );
+
+    /* STEP 3 – totalAssets() is now inflated */
+    const totalAssetsAfter = await dloop.totalAssets();
+    expect(totalAssetsAfter).to.be.gt(totalAssetsBefore);
+
+    /* STEP 4 – The vault reports an imbalanced leverage and blocks further
+       user interactions (TooImbalanced custom error). */
+    expect(await dloop.isTooImbalanced()).to.equal(true);
+
+    // Victim tries to deposit another 1 token ⇒ reverts because maxDeposit() is 0
+    await expect(
+      dloop.connect(victim).deposit(ethers.parseEther("1"), victim.address)
+    ).to.be.revertedWithCustomError(dloop, "ERC4626ExceededMaxDeposit");
+
+    // Victim tries to withdraw some assets ⇒ reverts with maxWithdraw() == 0
+    await expect(
+      dloop
+        .connect(victim)
+        .withdraw(ethers.parseEther("1"), victim.address, victim.address)
+    ).to.be.revertedWithCustomError(dloop, "ERC4626ExceededMaxWithdraw");
+  });
+});

--- a/tickets/2024-06-25-total-assets-manipulation.md
+++ b/tickets/2024-06-25-total-assets-manipulation.md
@@ -1,0 +1,45 @@
+# Ticket: Total Assets Manipulation via Foreign Collateral Supply
+
+## Summary
+`DLoopCoreBase.totalAssets()` incorrectly counts **all** collateral positions held by the vault address in the lending pool.  An attacker can deliberately supply an _unauthorised_ reserve (e.g. WETH) to the pool on behalf of the vault, inflating the collateral figure, pushing leverage calculations out-of-bounds and effectively _freezing_ deposits / withdrawals.
+
+The new test `test/dloop/DLoopCoreMock/foreign-collateral-supply-test.ts` reproduces this behaviour on the mock implementation.
+
+## Root Cause
+`totalAssets()` relies on `getTotalCollateralAndDebtOfUserInBase(address(this))`, which aggregates every reserve's collateral for the user address.  The vault logic assumes the only collateral token is `collateralToken`, but Aave treats the vault as a regular user: anyone can send additional collateral with `supply(token, amt, vault, …)`.
+
+## Impact
+1. `totalAssets()` becomes inflated.
+2. `getCurrentLeverageBps()` falls outside the configured bounds → `isTooImbalanced()` is `true`.
+3. Every ERC-4626 interface (`deposit`, `withdraw`, `redeem`, `mint`) reverts because `maxDeposit/maxWithdraw` return `0`.
+4. `increaseLeverage()` can be abused to borrow excessive debt at a subsidy, extracting value while locking the system.
+
+This is a permanent DoS / grief attack that can also lead to bad accounting and possible liquidation.
+
+## Proof-of-Concept
+See the new Hardhat test: `foreign-collateral-supply-test.ts`.  Steps:
+1. Legitimate user deposits 1 000 units of the authorised collateral.
+2. Attacker transfers **debtToken** to the vault and calls `supply` on behalf of the vault.
+3. `vault.totalAssets()` skyrockets and `isTooImbalanced()` turns `true`.
+4. Further deposits revert with `ERC4626ExceededMaxDeposit`; withdrawals revert with `ERC4626ExceededMaxWithdraw`.
+
+## Proposed Fix
+Count **only** the authorised collateral token position when reporting assets.  Two complementary actions:
+1. Replace `totalAssets()` implementation with direct aToken balance query of the designated collateral reserve, e.g.
+   ```solidity
+   function totalAssets() public view override returns (uint256) {
+       return getDTokenBalance(address(collateralToken));
+   }
+   ```
+   (For dLend this is the `aToken` of the collateral reserve.)
+2. Audit all usages of `getTotalCollateralAndDebtOfUserInBase` and ensure leverage / subsidy maths are based exclusively on the authorised reserve.
+
+## Tasks
+- [ ] Implement filtered `totalAssets()` (and possibly `getCurrentLeverageBps`) in **core** contracts.
+- [ ] Update any math that assumed aggregated collateral.
+- [ ] Add negative unit test ensuring external supply of foreign token no longer affects accounting.
+- [ ] Run full Hardhat + Foundry test suites.
+- [ ] Update documentation / README where relevant.
+
+---
+_created: 2024-06-25_ 


### PR DESCRIPTION
https://github.com/hats-finance/dTRINITY-0xee5c6f15e8d0b55a5eff84bb66beeee0e6140ffe/issues/119