### PR TITLE
DLoopDepositor `deposit` DoS due to `_swapExactOutput` accounting mismatch

### DIFF
--- a/contracts/testing/odos/MockOdosRouter.sol
+++ b/contracts/testing/odos/MockOdosRouter.sol
@@ -1,0 +1,41 @@
+pragma solidity 0.8.20;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+/**
+ * @title MockOdosRouter
+ * @notice Extremely simplified mock for the Odos V2 router – **only** the function
+ *         needed by the tests is implemented. It deliberately returns the *output*
+ *         token amount instead of the *input* token amount to mimic the behaviour
+ *         of the real Odos router that triggers the mismatch in `SwappableVault`.
+ */
+contract MockOdosRouter {
+    /**
+     * @dev Executes a fake swap that:
+     *      1. Pulls `amountOut * 2` of `inputToken` from the caller (simulates spending input).
+     *      2. Transfers exactly `amountOut` of `outputToken` to the caller.
+     *      3. Returns the output amount (mirroring Odos behaviour).
+     *
+     * This creates the condition `spentInputTokenAmount != returnedAmountIn` that
+     * triggers the revert in `SwappableVault._swapExactOutput`.
+     */
+    function swapExactOutput(
+        address inputToken,
+        address outputToken,
+        uint256 amountOut
+    ) external returns (uint256) {
+        uint256 amountIn = amountOut * 2;
+
+        // Pull the input tokens from the caller (they approved us beforehand).
+        ERC20(inputToken).transferFrom(msg.sender, address(this), amountIn);
+
+        // Send the requested output tokens to the caller.
+        ERC20(outputToken).transfer(msg.sender, amountOut);
+
+        // Mimic Odos: return the *output* amount, NOT the input spent.
+        return amountOut;
+    }
+
+    // Allow receiving native tokens in case tests fund the router.
+    receive() external payable {}
+}

--- a/test/dloop/DLoopDepositorOdos/revert-bug.test.ts
+++ b/test/dloop/DLoopDepositorOdos/revert-bug.test.ts
@@ -1,0 +1,153 @@
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import { expect } from "chai";
+import { ethers } from "hardhat";
+
+import {
+  DLoopCoreMock,
+  DLoopDepositorOdos,
+  TestERC20FlashMintable,
+  TestMintableERC20,
+} from "../../../typechain-types";
+
+import { deployDLoopMockLogic } from "../DLoopDepositorMock/fixtures";
+
+import {
+  ONE_PERCENT_BPS,
+  ONE_HUNDRED_PERCENT_BPS,
+} from "../../../typescript/common/bps_constants";
+
+/*
+ * This test reproduces the DoS bug caused by the mismatched accounting check in
+ * `SwappableVault._swapExactOutput`. The Odos implementation returns the *output*
+ * token amount, while `SwappableVault` expects the *input* token amount – the
+ * invariant therefore fails and the call reverts with
+ * `SpentInputTokenAmountNotEqualReturnedAmountIn`.
+ */
+
+describe("DLoopDepositorOdos – bug reproduction", function () {
+  async function fixture() {
+    // Deploy core mock directly (no nested loadFixture)
+    const coreFixture = await deployDLoopMockLogic();
+
+    const { dloopMock, collateralToken, debtToken, user1 } =
+      coreFixture as unknown as {
+        dloopMock: DLoopCoreMock;
+        collateralToken: TestMintableERC20;
+        debtToken: TestERC20FlashMintable;
+        user1: any;
+      };
+
+    // ----------------- Set mock prices so that vault math works ----------------
+    const DEFAULT_PRICE = 100000000; // 1e8 (same as fixtures)
+    await dloopMock.setMockPrice(
+      await collateralToken.getAddress(),
+      DEFAULT_PRICE
+    );
+    await dloopMock.setMockPrice(await debtToken.getAddress(), DEFAULT_PRICE);
+
+    // ----------------------- Deploy mock Odos router --------------------------
+    const MockRouterFactory = await ethers.getContractFactory("MockOdosRouter");
+    const mockRouter = (await MockRouterFactory.deploy()) as any;
+    await mockRouter.waitForDeployment();
+
+    // ------------------- Deploy OdosSwapLogic library -------------------------
+    const OdosSwapLogicFactory =
+      await ethers.getContractFactory("OdosSwapLogic");
+    const odosSwapLogic = await OdosSwapLogicFactory.deploy();
+    await odosSwapLogic.waitForDeployment();
+
+    // ------------------- Deploy DLoopDepositorOdos (linked) ------------------
+    const DepositorFactory = await ethers.getContractFactory(
+      "DLoopDepositorOdos",
+      {
+        libraries: {
+          OdosSwapLogic: await odosSwapLogic.getAddress(),
+        },
+      }
+    );
+
+    const depositor = (await DepositorFactory.deploy(
+      await debtToken.getAddress(), // flash lender == debt token (flash-mint)
+      await mockRouter.getAddress()
+    )) as DLoopDepositorOdos;
+    await depositor.waitForDeployment();
+
+    return {
+      dloopMock,
+      collateralToken,
+      debtToken,
+      depositor,
+      mockRouter,
+      user: user1,
+    };
+  }
+
+  it("reverts with SpentInputTokenAmountNotEqualReturnedAmountIn", async function () {
+    const {
+      dloopMock,
+      collateralToken,
+      debtToken,
+      depositor,
+      mockRouter,
+      user,
+    } = await loadFixture(fixture);
+
+    // --------------------- Prepare test parameters ---------------------------
+    const depositAmount = ethers.parseEther("100");
+    const slippageBps = 5 * ONE_PERCENT_BPS; // 5%
+
+    // User needs collateral tokens and approval
+    await collateralToken.mint(user.address, depositAmount);
+    await collateralToken
+      .connect(user)
+      .approve(await depositor.getAddress(), depositAmount);
+
+    // Compute minOutputShares (contract helper)
+    const minOutputShares = await depositor.calculateMinOutputShares(
+      depositAmount,
+      slippageBps,
+      dloopMock
+    );
+
+    // Compute requiredAdditionalCollateral to craft swapData & fund router
+    const leveragedAssets = await dloopMock.getLeveragedAssets(depositAmount);
+    const leveragedAssetsBn = BigInt(leveragedAssets);
+    const leveragedCollateralAmount =
+      (leveragedAssetsBn * BigInt(ONE_HUNDRED_PERCENT_BPS - slippageBps)) /
+      BigInt(ONE_HUNDRED_PERCENT_BPS);
+    const requiredAdditionalCollateral =
+      leveragedCollateralAmount - depositAmount;
+
+    // Fund the router with enough collateral tokens to send in the swap
+    await collateralToken.mint(
+      await mockRouter.getAddress(),
+      requiredAdditionalCollateral
+    );
+
+    // Encode swap data for `swapExactOutput(address,address,uint256)`
+    const swapData = mockRouter.interface.encodeFunctionData(
+      "swapExactOutput",
+      [
+        await debtToken.getAddress(),
+        await collateralToken.getAddress(),
+        requiredAdditionalCollateral,
+      ]
+    );
+
+    // Perform the leveraged deposit – expect revert with the specific custom error
+    await expect(
+      depositor
+        .connect(user)
+        .deposit(
+          depositAmount,
+          user.address,
+          minOutputShares,
+          swapData,
+          dloopMock
+        )
+    ).to.be.revertedWithCustomError(
+      depositor,
+      "SpentInputTokenAmountNotEqualReturnedAmountIn"
+    );
+  });
+});

--- a/tickets/bug-dloop-depositor-swap-mismatch.md
+++ b/tickets/bug-dloop-depositor-swap-mismatch.md
@@ -1,0 +1,51 @@
+# Ticket: DLoopDepositor `deposit` DoS due to `_swapExactOutput` accounting mismatch
+
+## Summary
+`DLoopDepositorBase.deposit()` reverts for every call whenever the underlying swap implementation returns the output–token amount instead of the **input**–token amount.  The revert is thrown in `SwappableVault._swapExactOutput` via the custom error
+`SpentInputTokenAmountNotEqualReturnedAmountIn`.
+
+## Root Cause
+```
+# contracts/common/SwappableVault.sol (excerpt)
+spentInputTokenAmount = inputTokenBalanceBefore - inputTokenBalanceAfter;
+...
+if (spentInputTokenAmount != amountIn) revert SpentInputTokenAmountNotEqualReturnedAmountIn;
+```
+
+`amountIn` **is assumed to be** the amount of *input* tokens spent, but every Odos-based implementation (`OdosSwapLogic.swapExactOutput`) returns the *output*-token amount it actually received.  Because the two values are denominated in different tokens, equality almost never holds and the call reverts.
+
+A dedicated regression test has been added at
+`test/dloop/DLoopDepositorOdos/revert-bug.test.ts`.  It:
+1. Deploys a minimal `MockOdosRouter` that mimics the real Odos return value behaviour.
+2. Executes `DLoopDepositorOdos.deposit()`.
+3. Expects the transaction to revert with `SpentInputTokenAmountNotEqualReturnedAmountIn`.
+
+## Impact
+* Denial of Service – no user can deposit through any `DLoopDepositor*` contract built on `SwappableVault`.
+* Other periphery contracts that rely on `_swapExactOutput` are also affected (increase/decrease leverage, redeemer, etc.).
+
+## Remediation Plan
+### Option A (preferred – keep invariant)
+1. **Modify every `_swapExactOutputImplementation` to return the real input-token amount.**
+   * For Odos: record `inputToken.balanceOf()` before and after performing the swap; the delta is the amount actually spent.
+   * Update the mock implementations (`SimpleDEXMock`, etc.) accordingly.
+2. Keep `SwappableVault._swapExactOutput` unchanged so the invariant continues to protect against unexpected behaviours.
+
+### Option B (quick but weaker)
+* Change `SwappableVault._swapExactOutput` to verify the *output*-token amount instead (or to remove the equality check entirely).  This is a smaller code change but drops an important safety assertion.
+
+## Tasks
+- [ ] Implement Option A for `OdosSwapLogic`.
+- [ ] Apply the same change to all mock venues.
+- [ ] Re-run the new regression test; it must now **fail** (no revert) – adjust expectation accordingly.
+- [ ] Add/adjust unit tests for other periphery contracts using `_swapExactOutput`.
+
+## Severity
+`High` – functional DoS to deposits (and other swaps) until fixed.
+
+## References
+* PR introducing these contracts: _link_
+* Regression test: `test/dloop/DLoopDepositorOdos/revert-bug.test.ts`
+
+---
+_Opened: 2024-06-25_ 


### PR DESCRIPTION
https://github.com/hats-finance/dTRINITY-0xee5c6f15e8d0b55a5eff84bb66beeee0e6140ffe/issues/124