### PR TITLE
Fix failing safe tests after recent changes

### DIFF
--- a/test/dstable/fixtures.ts
+++ b/test/dstable/fixtures.ts
@@ -30,7 +30,8 @@ export const createDStableFixture = (config: DStableFixtureConfig) => {
   return deployments.createFixture(async ({ deployments }) => {
     await deployments.fixture(); // Start from a fresh deployment
     await deployments.fixture(["local-setup", config.symbol.toLowerCase()]); // Include local-setup to use the mock Oracle
-    await deployments.fixture(["setup-issuerv2"]); // Ensure IssuerV2 is deployed and roles migrated
+    // Ensure IssuerV2 and RedeemerV2 are deployed and roles migrated to mirror mainnet
+    await deployments.fixture(["setup-issuerv2", "setup-redeemerv2"]);
   });
 };
 


### PR DESCRIPTION
Include `setup-redeemerv2` in dStable test fixtures to align test environment with mainnet Safe governance setup and fix RedeemerV2 role revocation tests.

The `RedeemerV2` role revocation tests were failing because the `COLLATERAL_WITHDRAWER_ROLE` was not being revoked from legacy redeemers in the test environment. This change ensures the `setup-redeemerv2` script runs during test fixture setup, mirroring the mainnet state where these roles are correctly revoked and allowing the tests to pass.

---
<a href="https://cursor.com/background-agent?bcId=bc-fb75cc12-44ec-429b-9344-81ee0684647a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fb75cc12-44ec-429b-9344-81ee0684647a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

