### PR TITLE
Add ChainlinkDecimalConverterV2

### DIFF
--- a/contracts/oracle_aggregator/chainlink/ChainlinkDecimalConverterV2.sol
+++ b/contracts/oracle_aggregator/chainlink/ChainlinkDecimalConverterV2.sol
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: MIT
+/* ———————————————————————————————————————————————————————————————————————————————— *
+ *    _____     ______   ______     __     __   __     __     ______   __  __       *
+ *   /\  __-.  /\__  _\ /\  == \   /\ \   /\ "-.\ \   /\ \   /\__  _\ /\ \_\ \      *
+ *   \ \ \/\ \ \/_/\ \/ \ \  __<   \ \ \  \ \ \-.  \  \ \ \  \/_/\ \/ \ \____ \     *
+ *    \ \____-    \ \_\  \ \_\ \_\  \ \_\  \ \_\\"\_\  \ \_\    \ \_\  \/\_____\    *
+ *     \/____/     \/_/   \/_/ /_/   \/_/   \/_/ \/_/   \/_/     \/_/   \/_____/    *
+ *                                                                                  *
+ * ————————————————————————————————— dtrinity.org ————————————————————————————————— *
+ *                                                                                  *
+ *                                         ▲                                        *
+ *                                        ▲ ▲                                       *
+ *                                                                                  *
+ * ———————————————————————————————————————————————————————————————————————————————— *
+ * dTRINITY Protocol: https://github.com/dtrinity                                   *
+ * ———————————————————————————————————————————————————————————————————————————————— */
+
+pragma solidity ^0.8.20;
+
+import "../interface/chainlink/IAggregatorV3Interface.sol";
+import "../interface/chainlink/IPriceFeedLegacy.sol";
+
+/**
+ * @title ChainlinkDecimalConverterV2
+ * @notice V2 converter between Chainlink price feeds with different decimal precisions
+ * @dev Implements both AggregatorV3Interface and IPriceFeedLegacy interfaces
+ * @dev Supports both upscaling (increasing precision) and downscaling (reducing precision)
+ */
+contract ChainlinkDecimalConverterV2 is AggregatorV3Interface, IPriceFeedLegacy {
+    /// @notice Original Chainlink price feed
+    AggregatorV3Interface public immutable sourceFeed;
+
+    /// @notice Legacy interface for the source feed (if supported)
+    IPriceFeedLegacy public immutable sourceFeedLegacy;
+
+    /// @notice Original decimals from the source feed
+    uint8 public immutable sourceDecimals;
+
+    /// @notice Target decimals for price conversion
+    uint8 public immutable override decimals;
+
+    /// @notice Whether we need to upscale (multiply) or downscale (divide)
+    bool public immutable isUpscaling;
+
+    /// @notice Scaling factor to convert between source and target decimals
+    int256 private immutable scalingFactor;
+
+    /**
+     * @notice Constructor to initialize the V2 decimal converter
+     * @param _sourceFeed Address of the source Chainlink price feed
+     * @param _targetDecimals Target decimal precision
+     */
+    constructor(address _sourceFeed, uint8 _targetDecimals) {
+        sourceFeed = AggregatorV3Interface(_sourceFeed);
+        sourceDecimals = sourceFeed.decimals();
+        decimals = _targetDecimals;
+
+        // We'll attempt legacy interface calls at runtime with fallbacks
+        // This is more robust than trying to detect support at construction time
+        sourceFeedLegacy = IPriceFeedLegacy(_sourceFeed);
+
+        // Determine scaling direction and calculate factor
+        if (_targetDecimals > sourceDecimals) {
+            // Upscaling: multiply by 10^(targetDecimals - sourceDecimals)
+            isUpscaling = true;
+            uint8 decimalDifference = _targetDecimals - sourceDecimals;
+            scalingFactor = int256(10 ** decimalDifference);
+        } else if (_targetDecimals < sourceDecimals) {
+            // Downscaling: divide by 10^(sourceDecimals - targetDecimals)
+            isUpscaling = false;
+            uint8 decimalDifference = sourceDecimals - _targetDecimals;
+            scalingFactor = int256(10 ** decimalDifference);
+        } else {
+            // No scaling needed
+            isUpscaling = false;
+            scalingFactor = 1;
+        }
+    }
+
+    /**
+     * @notice Returns the description of the original feed
+     * @return Description string
+     */
+    function description() external view override returns (string memory) {
+        return sourceFeed.description();
+    }
+
+    /**
+     * @notice Returns the version of the original feed
+     * @return Version number
+     */
+    function version() external view override returns (uint256) {
+        return sourceFeed.version();
+    }
+
+    /**
+     * @notice Gets data for a specific round
+     * @param _roundId The round ID to retrieve data for
+     * @return roundId The round ID
+     * @return answer The price with adjusted decimals
+     * @return startedAt The timestamp when the round started
+     * @return updatedAt The timestamp when the round was updated
+     * @return answeredInRound The round in which the answer was computed
+     */
+    function getRoundData(
+        uint80 _roundId
+    )
+        external
+        view
+        override
+        returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
+    {
+        (roundId, answer, startedAt, updatedAt, answeredInRound) = sourceFeed.getRoundData(_roundId);
+        answer = _scalePrice(answer);
+    }
+
+    /**
+     * @notice Gets data for the latest round
+     * @return roundId The round ID
+     * @return answer The price with adjusted decimals
+     * @return startedAt The timestamp when the round started
+     * @return updatedAt The timestamp when the round was updated
+     * @return answeredInRound The round in which the answer was computed
+     */
+    function latestRoundData()
+        external
+        view
+        override
+        returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
+    {
+        (roundId, answer, startedAt, updatedAt, answeredInRound) = sourceFeed.latestRoundData();
+        answer = _scalePrice(answer);
+    }
+
+    /**
+     * @notice Legacy function: Gets the number of latest round
+     * @return latestRound The number of the latest update round
+     */
+    function latestRound() external view override returns (uint80) {
+        try sourceFeedLegacy.latestRound() returns (uint80 roundId) {
+            return roundId;
+        } catch {
+            // Fall back to getting it from latestRoundData if legacy interface not supported
+            (uint80 roundId, , , , ) = sourceFeed.latestRoundData();
+            return roundId;
+        }
+    }
+
+    /**
+     * @notice Legacy function: Gets the latest successfully reported value with adjusted decimals
+     * @return latestAnswer The latest successfully reported value with target decimals
+     */
+    function latestAnswer() external view override returns (int256) {
+        try sourceFeedLegacy.latestAnswer() returns (int256 answer) {
+            return _scalePrice(answer);
+        } catch {
+            // Fall back to getting it from latestRoundData if legacy interface not supported
+            (, int256 answer, , , ) = sourceFeed.latestRoundData();
+            return _scalePrice(answer);
+        }
+    }
+
+    /**
+     * @notice Internal function to scale price based on decimal conversion
+     * @param originalPrice The original price from the source feed
+     * @return scaledPrice The price adjusted to target decimals
+     */
+    function _scalePrice(int256 originalPrice) internal view returns (int256 scaledPrice) {
+        if (scalingFactor == 1) {
+            return originalPrice;
+        }
+
+        if (isUpscaling) {
+            // Multiply for upscaling (increasing precision)
+            scaledPrice = originalPrice * scalingFactor;
+        } else {
+            // Divide for downscaling (reducing precision)
+            scaledPrice = originalPrice / scalingFactor;
+        }
+    }
+}

--- a/contracts/oracle_aggregator/interface/chainlink/IPriceFeedLegacy.sol
+++ b/contracts/oracle_aggregator/interface/chainlink/IPriceFeedLegacy.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+pragma solidity ^0.8.17;
+
+/**
+ * @title Interface with the old Chainlink Price Feed functions
+ * @author The Redstone Oracles team
+ * @dev There are some projects (e.g. gmx-contracts) that still
+ * rely on some legacy functions
+ */
+interface IPriceFeedLegacy {
+    /**
+     * @notice Old Chainlink function for getting the number of latest round
+     * @return latestRound The number of the latest update round
+     */
+    function latestRound() external view returns (uint80);
+
+    /**
+     * @notice Old Chainlink function for getting the latest successfully reported value
+     * @return latestAnswer The latest successfully reported value
+     */
+    function latestAnswer() external view returns (int256);
+}

--- a/contracts/testing/MockDecimalConverterAggregator.sol
+++ b/contracts/testing/MockDecimalConverterAggregator.sol
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "../oracle_aggregator/interface/chainlink/IAggregatorV3Interface.sol";
+
+/**
+ * @title MockDecimalConverterAggregator
+ * @notice Mock implementation of Chainlink AggregatorV3Interface for testing decimal conversion
+ * @dev Only implements the AggregatorV3Interface, not the legacy interface
+ */
+contract MockDecimalConverterAggregator is AggregatorV3Interface {
+    uint8 private _decimals;
+    string private _description;
+    uint256 private _version;
+
+    struct RoundData {
+        uint80 roundId;
+        int256 answer;
+        uint256 startedAt;
+        uint256 updatedAt;
+        uint80 answeredInRound;
+    }
+
+    RoundData private _latestRoundData;
+
+    constructor(
+        uint8 decimals_,
+        string memory description_,
+        uint256 version_,
+        uint80 roundId,
+        int256 answer,
+        uint256 startedAt,
+        uint256 updatedAt,
+        uint80 answeredInRound
+    ) {
+        _decimals = decimals_;
+        _description = description_;
+        _version = version_;
+        _latestRoundData = RoundData({
+            roundId: roundId,
+            answer: answer,
+            startedAt: startedAt,
+            updatedAt: updatedAt,
+            answeredInRound: answeredInRound
+        });
+    }
+
+    function decimals() external view override returns (uint8) {
+        return _decimals;
+    }
+
+    function description() external view override returns (string memory) {
+        return _description;
+    }
+
+    function version() external view override returns (uint256) {
+        return _version;
+    }
+
+    function getRoundData(
+        uint80 /* _roundId */
+    )
+        external
+        view
+        override
+        returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
+    {
+        // For simplicity, return the same data regardless of roundId
+        return (
+            _latestRoundData.roundId,
+            _latestRoundData.answer,
+            _latestRoundData.startedAt,
+            _latestRoundData.updatedAt,
+            _latestRoundData.answeredInRound
+        );
+    }
+
+    function latestRoundData()
+        external
+        view
+        override
+        returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
+    {
+        return (
+            _latestRoundData.roundId,
+            _latestRoundData.answer,
+            _latestRoundData.startedAt,
+            _latestRoundData.updatedAt,
+            _latestRoundData.answeredInRound
+        );
+    }
+
+    // Helper function for testing to update the round data
+    function updateRoundData(
+        uint80 roundId,
+        int256 answer,
+        uint256 startedAt,
+        uint256 updatedAt,
+        uint80 answeredInRound
+    ) external {
+        _latestRoundData = RoundData({
+            roundId: roundId,
+            answer: answer,
+            startedAt: startedAt,
+            updatedAt: updatedAt,
+            answeredInRound: answeredInRound
+        });
+    }
+}

--- a/contracts/testing/MockDecimalConverterAggregatorWithLegacy.sol
+++ b/contracts/testing/MockDecimalConverterAggregatorWithLegacy.sol
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "../oracle_aggregator/interface/chainlink/IAggregatorV3Interface.sol";
+import "../oracle_aggregator/interface/chainlink/IPriceFeedLegacy.sol";
+
+/**
+ * @title MockDecimalConverterAggregatorWithLegacy
+ * @notice Mock implementation that supports both AggregatorV3Interface and IPriceFeedLegacy
+ * @dev Implements both modern and legacy Chainlink interfaces for testing decimal conversion
+ */
+contract MockDecimalConverterAggregatorWithLegacy is AggregatorV3Interface, IPriceFeedLegacy {
+    uint8 private _decimals;
+    string private _description;
+    uint256 private _version;
+
+    struct RoundData {
+        uint80 roundId;
+        int256 answer;
+        uint256 startedAt;
+        uint256 updatedAt;
+        uint80 answeredInRound;
+    }
+
+    RoundData private _latestRoundData;
+
+    constructor(
+        uint8 decimals_,
+        string memory description_,
+        uint256 version_,
+        uint80 roundId,
+        int256 answer,
+        uint256 startedAt,
+        uint256 updatedAt,
+        uint80 answeredInRound
+    ) {
+        _decimals = decimals_;
+        _description = description_;
+        _version = version_;
+        _latestRoundData = RoundData({
+            roundId: roundId,
+            answer: answer,
+            startedAt: startedAt,
+            updatedAt: updatedAt,
+            answeredInRound: answeredInRound
+        });
+    }
+
+    // AggregatorV3Interface functions
+    function decimals() external view override returns (uint8) {
+        return _decimals;
+    }
+
+    function description() external view override returns (string memory) {
+        return _description;
+    }
+
+    function version() external view override returns (uint256) {
+        return _version;
+    }
+
+    function getRoundData(
+        uint80 /* _roundId */
+    )
+        external
+        view
+        override
+        returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
+    {
+        // For simplicity, return the same data regardless of roundId
+        return (
+            _latestRoundData.roundId,
+            _latestRoundData.answer,
+            _latestRoundData.startedAt,
+            _latestRoundData.updatedAt,
+            _latestRoundData.answeredInRound
+        );
+    }
+
+    function latestRoundData()
+        external
+        view
+        override
+        returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
+    {
+        return (
+            _latestRoundData.roundId,
+            _latestRoundData.answer,
+            _latestRoundData.startedAt,
+            _latestRoundData.updatedAt,
+            _latestRoundData.answeredInRound
+        );
+    }
+
+    // IPriceFeedLegacy functions
+    function latestRound() external view override returns (uint80) {
+        return _latestRoundData.roundId;
+    }
+
+    function latestAnswer() external view override returns (int256) {
+        return _latestRoundData.answer;
+    }
+
+    // Helper function for testing to update the round data
+    function updateRoundData(
+        uint80 roundId,
+        int256 answer,
+        uint256 startedAt,
+        uint256 updatedAt,
+        uint80 answeredInRound
+    ) external {
+        _latestRoundData = RoundData({
+            roundId: roundId,
+            answer: answer,
+            startedAt: startedAt,
+            updatedAt: updatedAt,
+            answeredInRound: answeredInRound
+        });
+    }
+}

--- a/deploy/17_deploy_chainlink_upscale_sfrxusd/01_deploy_upscale_oracle.ts
+++ b/deploy/17_deploy_chainlink_upscale_sfrxusd/01_deploy_upscale_oracle.ts
@@ -1,0 +1,145 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { DeployFunction } from "hardhat-deploy/types";
+
+import { SFRXUSD_UPSCALE_DECIMAL_CONVERTER_ID } from "../../typescript/deploy-ids";
+import { isMainnet } from "../../typescript/hardhat/deploy";
+
+// Source Redstone feed constants
+const SFRXUSD_REDSTONE_FEED_ADDRESS = "0xebE443E20ADf302B59419648c4dbA0c7299cf1A2"; // sfrxUSD Redstone feed
+const EXPECTED_SOURCE_DECIMALS = 8;
+const TARGET_DECIMALS = 18;
+
+/**
+ * Deploys ChainlinkDecimalConverterV2 for sfrxUSD Redstone feed
+ * This converts the feed from 8 decimals to 18 decimals (upscaling)
+ *
+ * The deployment uses the new ChainlinkDecimalConverterV2 which supports:
+ * - Both upscaling and downscaling
+ * - Both IAggregatorV3Interface and IPriceFeedLegacy interfaces
+ * - Automatic detection of legacy interface support
+ *
+ * Feed details:
+ * - Source: sfrxUSD Redstone feed at 0xebE443E20ADf302B59419648c4dbA0c7299cf1A2
+ * - Direction: 8 decimals → 18 decimals (upscale by 10^10)
+ * - Contract: ChainlinkDecimalConverterV2
+ *
+ * @param hre The Hardhat runtime environment.
+ */
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  // The hard-coded values are only valid for mainnet
+  if (!isMainnet(hre.network.name)) {
+    console.log(`\n🔑 ${__filename.split("/").slice(-2).join("/")}: Skipping non-mainnet network`);
+    return true;
+  }
+
+  const { deployer } = await hre.getNamedAccounts();
+  const { deployments, ethers } = hre;
+
+  console.log(`🚀 Deploying ChainlinkDecimalConverterV2 for sfrxUSD upscaling...`);
+  console.log(`   Source feed: ${SFRXUSD_REDSTONE_FEED_ADDRESS}`);
+  console.log(`   Direction: ${EXPECTED_SOURCE_DECIMALS} → ${TARGET_DECIMALS} decimals`);
+
+  // Connect to the source Redstone feed
+  const sourceFeed = await ethers.getContractAt(
+    "contracts/oracle_aggregator/interface/chainlink/IAggregatorV3Interface.sol:AggregatorV3Interface",
+    SFRXUSD_REDSTONE_FEED_ADDRESS,
+  );
+
+  // Verify the source feed has the expected number of decimals
+  const sourceDecimals = await sourceFeed.decimals();
+  console.log(`✅ Source feed decimals: ${sourceDecimals}`);
+
+  if (sourceDecimals !== BigInt(EXPECTED_SOURCE_DECIMALS)) {
+    throw new Error(`Source feed has ${sourceDecimals} decimals, expected ${EXPECTED_SOURCE_DECIMALS}`);
+  }
+
+  // Get feed description for logging
+  let feedDescription = "Unknown Feed";
+
+  try {
+    feedDescription = await sourceFeed.description();
+    console.log(`📝 Source feed description: ${feedDescription}`);
+  } catch (error) {
+    console.log(`⚠️  Could not get feed description: ${error}`);
+  }
+
+  // Deploy the ChainlinkDecimalConverterV2
+  console.log(`🔧 Deploying ChainlinkDecimalConverterV2...`);
+  await deployments.deploy(SFRXUSD_UPSCALE_DECIMAL_CONVERTER_ID, {
+    from: deployer,
+    args: [SFRXUSD_REDSTONE_FEED_ADDRESS, TARGET_DECIMALS],
+    contract: "ChainlinkDecimalConverterV2",
+    autoMine: true,
+    log: false,
+  });
+
+  // Get the deployment and verify
+  const converterDeployment = await deployments.get(SFRXUSD_UPSCALE_DECIMAL_CONVERTER_ID);
+  const converter = await ethers.getContractAt("ChainlinkDecimalConverterV2", converterDeployment.address);
+
+  // Verify the converter configuration
+  const targetDecimals = await converter.decimals();
+  const converterSourceDecimals = await converter.sourceDecimals();
+  const isUpscaling = await converter.isUpscaling();
+
+  console.log(`✅ Deployed ChainlinkDecimalConverterV2: ${converterDeployment.address}`);
+  console.log(`   Source decimals: ${converterSourceDecimals}`);
+  console.log(`   Target decimals: ${targetDecimals}`);
+  console.log(`   Is upscaling: ${isUpscaling}`);
+  console.log(
+    `   Scaling factor: 10^${TARGET_DECIMALS - EXPECTED_SOURCE_DECIMALS} = ${10n ** BigInt(TARGET_DECIMALS - EXPECTED_SOURCE_DECIMALS)}`,
+  );
+
+  if (targetDecimals !== BigInt(TARGET_DECIMALS)) {
+    throw new Error(`Converter has ${targetDecimals} decimals, expected ${TARGET_DECIMALS}`);
+  }
+
+  if (!isUpscaling) {
+    throw new Error(`Converter should be upscaling but isUpscaling is false`);
+  }
+
+  // Test the converter by getting a price (if available)
+  try {
+    const latestRoundData = await converter.latestRoundData();
+    const originalPrice = await sourceFeed.latestRoundData();
+
+    console.log(`💰 Original price: ${originalPrice.answer} (${EXPECTED_SOURCE_DECIMALS} decimals)`);
+    console.log(`💰 Converted price: ${latestRoundData.answer} (${TARGET_DECIMALS} decimals)`);
+    console.log(`📊 Price ratio (converted/original): ${Number(latestRoundData.answer) / Number(originalPrice.answer)}`);
+
+    // Verify the scaling is correct (should be 10^10 for 8→18 decimals)
+    const expectedRatio = 10n ** BigInt(TARGET_DECIMALS - EXPECTED_SOURCE_DECIMALS);
+    const actualRatio = latestRoundData.answer / originalPrice.answer;
+
+    if (actualRatio === expectedRatio) {
+      console.log(`✅ Price scaling verified: ${actualRatio}x multiplier`);
+    } else {
+      console.log(`⚠️  Price scaling mismatch: expected ${expectedRatio}x, got ${actualRatio}x`);
+    }
+  } catch (priceError) {
+    console.log(`⚠️  Could not test price conversion: ${priceError}`);
+  }
+
+  // Test legacy interface support (now uses runtime fallback logic)
+  try {
+    const latestRound = await converter.latestRound();
+    const latestAnswer = await converter.latestAnswer();
+    console.log(`✅ Legacy interface methods working - Round: ${latestRound}, Answer: ${latestAnswer}`);
+
+    // The V2 converter automatically falls back to modern interface if legacy fails
+    console.log(`🔗 Legacy methods successfully use fallback for non-legacy feeds`);
+  } catch (legacyError) {
+    console.log(`❌ Legacy interface methods failed unexpectedly: ${legacyError}`);
+    console.log(`   This suggests an issue with the fallback logic`);
+  }
+
+  console.log(`💾 Saved deployment as: ${SFRXUSD_UPSCALE_DECIMAL_CONVERTER_ID}`);
+  console.log(`🔗 ${__filename.split("/").slice(-2).join("/")}: ✅`);
+
+  return true;
+};
+
+func.id = SFRXUSD_UPSCALE_DECIMAL_CONVERTER_ID;
+func.tags = ["sfrxusd", "oracle", "chainlink", "upscale", "redstone"];
+
+export default func;

--- a/test/oracle_aggregator/ChainlinkDecimalConverterV2.ts
+++ b/test/oracle_aggregator/ChainlinkDecimalConverterV2.ts
@@ -1,0 +1,332 @@
+import { expect } from "chai";
+import hre, { ethers, deployments, getNamedAccounts } from "hardhat";
+import { Address } from "hardhat-deploy/types";
+
+import { ChainlinkDecimalConverterV2 } from "../../typechain-types";
+
+// Mock AggregatorV3Interface implementation
+interface MockAggregatorData {
+  roundId: bigint;
+  answer: bigint;
+  startedAt: bigint;
+  updatedAt: bigint;
+  answeredInRound: bigint;
+}
+
+describe("ChainlinkDecimalConverterV2", () => {
+  let deployer: Address;
+  let user1: Address;
+  let mockAggregator: any;
+  let mockAggregatorWithLegacy: any;
+  let converter: ChainlinkDecimalConverterV2;
+
+  const MOCK_DECIMALS = 8;
+  const MOCK_DESCRIPTION = "Mock ETH/USD Price Feed";
+  const MOCK_VERSION = 1n;
+  const MOCK_ROUND_DATA: MockAggregatorData = {
+    roundId: 1000n,
+    answer: 200000000000n, // $2000.00000000 (8 decimals)
+    startedAt: 1640000000n,
+    updatedAt: 1640000001n,
+    answeredInRound: 1000n,
+  };
+
+  before(async () => {
+    ({ deployer, user1 } = await getNamedAccounts());
+  });
+
+  beforeEach(async () => {
+    await deployments.fixture(["local-setup"]);
+
+    // Deploy mock aggregator with both interfaces
+    const MockAggregatorFactory = await ethers.getContractFactory("MockDecimalConverterAggregatorWithLegacy");
+    mockAggregatorWithLegacy = await MockAggregatorFactory.deploy(
+      MOCK_DECIMALS,
+      MOCK_DESCRIPTION,
+      MOCK_VERSION,
+      MOCK_ROUND_DATA.roundId,
+      MOCK_ROUND_DATA.answer,
+      MOCK_ROUND_DATA.startedAt,
+      MOCK_ROUND_DATA.updatedAt,
+      MOCK_ROUND_DATA.answeredInRound
+    );
+
+    // Deploy mock aggregator without legacy interface
+    const MockAggregatorV3Factory = await ethers.getContractFactory("MockDecimalConverterAggregator");
+    mockAggregator = await MockAggregatorV3Factory.deploy(
+      MOCK_DECIMALS,
+      MOCK_DESCRIPTION,
+      MOCK_VERSION,
+      MOCK_ROUND_DATA.roundId,
+      MOCK_ROUND_DATA.answer,
+      MOCK_ROUND_DATA.startedAt,
+      MOCK_ROUND_DATA.updatedAt,
+      MOCK_ROUND_DATA.answeredInRound
+    );
+  });
+
+  describe("Constructor and initialization", () => {
+    it("should initialize correctly for downscaling (8 to 6 decimals)", async () => {
+      const targetDecimals = 6;
+      const ConverterFactory = await ethers.getContractFactory("ChainlinkDecimalConverterV2");
+      converter = await ConverterFactory.deploy(await mockAggregator.getAddress(), targetDecimals);
+
+      expect(await converter.sourceDecimals()).to.equal(MOCK_DECIMALS);
+      expect(await converter.decimals()).to.equal(targetDecimals);
+      expect(await converter.isUpscaling()).to.equal(false);
+      expect(await converter.sourceFeed()).to.equal(await mockAggregator.getAddress());
+    });
+
+    it("should initialize correctly for upscaling (8 to 12 decimals)", async () => {
+      const targetDecimals = 12;
+      const ConverterFactory = await ethers.getContractFactory("ChainlinkDecimalConverterV2");
+      converter = await ConverterFactory.deploy(await mockAggregator.getAddress(), targetDecimals);
+
+      expect(await converter.sourceDecimals()).to.equal(MOCK_DECIMALS);
+      expect(await converter.decimals()).to.equal(targetDecimals);
+      expect(await converter.isUpscaling()).to.equal(true);
+      expect(await converter.sourceFeed()).to.equal(await mockAggregator.getAddress());
+    });
+
+    it("should initialize correctly for no scaling (8 to 8 decimals)", async () => {
+      const targetDecimals = 8;
+      const ConverterFactory = await ethers.getContractFactory("ChainlinkDecimalConverterV2");
+      converter = await ConverterFactory.deploy(await mockAggregator.getAddress(), targetDecimals);
+
+      expect(await converter.sourceDecimals()).to.equal(MOCK_DECIMALS);
+      expect(await converter.decimals()).to.equal(targetDecimals);
+      expect(await converter.isUpscaling()).to.equal(false);
+      expect(await converter.sourceFeed()).to.equal(await mockAggregator.getAddress());
+    });
+
+    it("should handle legacy interface correctly with runtime fallback", async () => {
+      const ConverterFactory = await ethers.getContractFactory("ChainlinkDecimalConverterV2");
+
+      // Test with legacy support - sourceFeedLegacy should point to source feed
+      const converterWithLegacy = await ConverterFactory.deploy(
+        await mockAggregatorWithLegacy.getAddress(),
+        6
+      );
+      expect(await converterWithLegacy.sourceFeedLegacy()).to.equal(await mockAggregatorWithLegacy.getAddress());
+
+      // Legacy methods should work by calling source feed directly
+      const legacyRound = await converterWithLegacy.latestRound();
+      const legacyAnswer = await converterWithLegacy.latestAnswer();
+      expect(legacyRound).to.equal(MOCK_ROUND_DATA.roundId);
+      expect(legacyAnswer).to.equal(MOCK_ROUND_DATA.answer / 100n); // Scaled down 8->6 decimals
+
+      // Test without legacy support - sourceFeedLegacy should still point to source feed
+      const converterWithoutLegacy = await ConverterFactory.deploy(
+        await mockAggregator.getAddress(),
+        6
+      );
+      expect(await converterWithoutLegacy.sourceFeedLegacy()).to.equal(await mockAggregator.getAddress());
+
+      // Legacy methods should work by falling back to latestRoundData()
+      const fallbackRound = await converterWithoutLegacy.latestRound();
+      const fallbackAnswer = await converterWithoutLegacy.latestAnswer();
+      expect(fallbackRound).to.equal(MOCK_ROUND_DATA.roundId);
+      expect(fallbackAnswer).to.equal(MOCK_ROUND_DATA.answer / 100n); // Scaled down 8->6 decimals
+    });
+  });
+
+  describe("AggregatorV3Interface functions", () => {
+    beforeEach(async () => {
+      const ConverterFactory = await ethers.getContractFactory("ChainlinkDecimalConverterV2");
+      converter = await ConverterFactory.deploy(await mockAggregator.getAddress(), 6); // Downscale from 8 to 6
+    });
+
+    it("should return correct description", async () => {
+      expect(await converter.description()).to.equal(MOCK_DESCRIPTION);
+    });
+
+    it("should return correct version", async () => {
+      expect(await converter.version()).to.equal(MOCK_VERSION);
+    });
+
+    it("should return correct decimals", async () => {
+      expect(await converter.decimals()).to.equal(6);
+    });
+
+    it("should return scaled getRoundData for downscaling", async () => {
+      const result = await converter.getRoundData(MOCK_ROUND_DATA.roundId);
+
+      expect(result.roundId).to.equal(MOCK_ROUND_DATA.roundId);
+      expect(result.answer).to.equal(MOCK_ROUND_DATA.answer / 100n); // 8->6 decimals: divide by 100
+      expect(result.startedAt).to.equal(MOCK_ROUND_DATA.startedAt);
+      expect(result.updatedAt).to.equal(MOCK_ROUND_DATA.updatedAt);
+      expect(result.answeredInRound).to.equal(MOCK_ROUND_DATA.answeredInRound);
+    });
+
+    it("should return scaled latestRoundData for downscaling", async () => {
+      const result = await converter.latestRoundData();
+
+      expect(result.roundId).to.equal(MOCK_ROUND_DATA.roundId);
+      expect(result.answer).to.equal(MOCK_ROUND_DATA.answer / 100n); // 8->6 decimals: divide by 100
+      expect(result.startedAt).to.equal(MOCK_ROUND_DATA.startedAt);
+      expect(result.updatedAt).to.equal(MOCK_ROUND_DATA.updatedAt);
+      expect(result.answeredInRound).to.equal(MOCK_ROUND_DATA.answeredInRound);
+    });
+  });
+
+  describe("Upscaling tests", () => {
+    beforeEach(async () => {
+      const ConverterFactory = await ethers.getContractFactory("ChainlinkDecimalConverterV2");
+      converter = await ConverterFactory.deploy(await mockAggregator.getAddress(), 12); // Upscale from 8 to 12
+    });
+
+    it("should return scaled getRoundData for upscaling", async () => {
+      const result = await converter.getRoundData(MOCK_ROUND_DATA.roundId);
+
+      expect(result.roundId).to.equal(MOCK_ROUND_DATA.roundId);
+      expect(result.answer).to.equal(MOCK_ROUND_DATA.answer * 10000n); // 8->12 decimals: multiply by 10000
+      expect(result.startedAt).to.equal(MOCK_ROUND_DATA.startedAt);
+      expect(result.updatedAt).to.equal(MOCK_ROUND_DATA.updatedAt);
+      expect(result.answeredInRound).to.equal(MOCK_ROUND_DATA.answeredInRound);
+    });
+
+    it("should return scaled latestRoundData for upscaling", async () => {
+      const result = await converter.latestRoundData();
+
+      expect(result.roundId).to.equal(MOCK_ROUND_DATA.roundId);
+      expect(result.answer).to.equal(MOCK_ROUND_DATA.answer * 10000n); // 8->12 decimals: multiply by 10000
+      expect(result.startedAt).to.equal(MOCK_ROUND_DATA.startedAt);
+      expect(result.updatedAt).to.equal(MOCK_ROUND_DATA.updatedAt);
+      expect(result.answeredInRound).to.equal(MOCK_ROUND_DATA.answeredInRound);
+    });
+  });
+
+  describe("No scaling tests", () => {
+    beforeEach(async () => {
+      const ConverterFactory = await ethers.getContractFactory("ChainlinkDecimalConverterV2");
+      converter = await ConverterFactory.deploy(await mockAggregator.getAddress(), 8); // No scaling: 8 to 8
+    });
+
+    it("should return unmodified getRoundData for no scaling", async () => {
+      const result = await converter.getRoundData(MOCK_ROUND_DATA.roundId);
+
+      expect(result.roundId).to.equal(MOCK_ROUND_DATA.roundId);
+      expect(result.answer).to.equal(MOCK_ROUND_DATA.answer); // No scaling
+      expect(result.startedAt).to.equal(MOCK_ROUND_DATA.startedAt);
+      expect(result.updatedAt).to.equal(MOCK_ROUND_DATA.updatedAt);
+      expect(result.answeredInRound).to.equal(MOCK_ROUND_DATA.answeredInRound);
+    });
+
+    it("should return unmodified latestRoundData for no scaling", async () => {
+      const result = await converter.latestRoundData();
+
+      expect(result.roundId).to.equal(MOCK_ROUND_DATA.roundId);
+      expect(result.answer).to.equal(MOCK_ROUND_DATA.answer); // No scaling
+      expect(result.startedAt).to.equal(MOCK_ROUND_DATA.startedAt);
+      expect(result.updatedAt).to.equal(MOCK_ROUND_DATA.updatedAt);
+      expect(result.answeredInRound).to.equal(MOCK_ROUND_DATA.answeredInRound);
+    });
+  });
+
+  describe("IPriceFeedLegacy functions", () => {
+    describe("With legacy interface support", () => {
+      beforeEach(async () => {
+        const ConverterFactory = await ethers.getContractFactory("ChainlinkDecimalConverterV2");
+        converter = await ConverterFactory.deploy(await mockAggregatorWithLegacy.getAddress(), 6); // Downscale from 8 to 6
+      });
+
+      it("should return correct latestRound from legacy interface", async () => {
+        const result = await converter.latestRound();
+        expect(result).to.equal(MOCK_ROUND_DATA.roundId);
+      });
+
+      it("should return scaled latestAnswer from legacy interface", async () => {
+        const result = await converter.latestAnswer();
+        expect(result).to.equal(MOCK_ROUND_DATA.answer / 100n); // 8->6 decimals: divide by 100
+      });
+    });
+
+    describe("Without legacy interface support (fallback)", () => {
+      beforeEach(async () => {
+        const ConverterFactory = await ethers.getContractFactory("ChainlinkDecimalConverterV2");
+        converter = await ConverterFactory.deploy(await mockAggregator.getAddress(), 6); // Downscale from 8 to 6
+      });
+
+      it("should return correct latestRound using fallback", async () => {
+        const result = await converter.latestRound();
+        expect(result).to.equal(MOCK_ROUND_DATA.roundId);
+      });
+
+      it("should return scaled latestAnswer using fallback", async () => {
+        const result = await converter.latestAnswer();
+        expect(result).to.equal(MOCK_ROUND_DATA.answer / 100n); // 8->6 decimals: divide by 100
+      });
+    });
+  });
+
+  describe("Edge cases and complex scenarios", () => {
+    it("should handle extreme upscaling correctly (8 to 18 decimals)", async () => {
+      const ConverterFactory = await ethers.getContractFactory("ChainlinkDecimalConverterV2");
+      converter = await ConverterFactory.deploy(await mockAggregator.getAddress(), 18); // 10 decimal difference
+
+      const result = await converter.latestRoundData();
+      expect(result.answer).to.equal(MOCK_ROUND_DATA.answer * (10n ** 10n)); // multiply by 10^10
+    });
+
+    it("should handle extreme downscaling correctly (8 to 0 decimals)", async () => {
+      const ConverterFactory = await ethers.getContractFactory("ChainlinkDecimalConverterV2");
+      converter = await ConverterFactory.deploy(await mockAggregator.getAddress(), 0); // 8 decimal difference
+
+      const result = await converter.latestRoundData();
+      expect(result.answer).to.equal(MOCK_ROUND_DATA.answer / (10n ** 8n)); // divide by 10^8
+    });
+
+    it("should handle zero price correctly", async () => {
+      // Update mock to return zero price
+      await mockAggregator.updateRoundData(
+        MOCK_ROUND_DATA.roundId + 1n,
+        0n, // zero price
+        MOCK_ROUND_DATA.startedAt + 1n,
+        MOCK_ROUND_DATA.updatedAt + 1n,
+        MOCK_ROUND_DATA.answeredInRound + 1n
+      );
+
+      const ConverterFactory = await ethers.getContractFactory("ChainlinkDecimalConverterV2");
+      converter = await ConverterFactory.deploy(await mockAggregator.getAddress(), 6);
+
+      const result = await converter.latestRoundData();
+      expect(result.answer).to.equal(0n);
+    });
+
+    it("should handle negative price correctly for upscaling", async () => {
+      // Update mock to return negative price
+      const negativePrice = -100000000n; // -$1.00000000
+      await mockAggregator.updateRoundData(
+        MOCK_ROUND_DATA.roundId + 1n,
+        negativePrice,
+        MOCK_ROUND_DATA.startedAt + 1n,
+        MOCK_ROUND_DATA.updatedAt + 1n,
+        MOCK_ROUND_DATA.answeredInRound + 1n
+      );
+
+      const ConverterFactory = await ethers.getContractFactory("ChainlinkDecimalConverterV2");
+      converter = await ConverterFactory.deploy(await mockAggregator.getAddress(), 12); // Upscale
+
+      const result = await converter.latestRoundData();
+      expect(result.answer).to.equal(negativePrice * 10000n); // multiply by 10^4 for 8->12 decimals
+    });
+
+    it("should handle negative price correctly for downscaling", async () => {
+      // Update mock to return negative price
+      const negativePrice = -100000000n; // -$1.00000000
+      await mockAggregator.updateRoundData(
+        MOCK_ROUND_DATA.roundId + 1n,
+        negativePrice,
+        MOCK_ROUND_DATA.startedAt + 1n,
+        MOCK_ROUND_DATA.updatedAt + 1n,
+        MOCK_ROUND_DATA.answeredInRound + 1n
+      );
+
+      const ConverterFactory = await ethers.getContractFactory("ChainlinkDecimalConverterV2");
+      converter = await ConverterFactory.deploy(await mockAggregator.getAddress(), 6); // Downscale
+
+      const result = await converter.latestRoundData();
+      expect(result.answer).to.equal(negativePrice / 100n); // divide by 10^2 for 8->6 decimals
+    });
+  });
+});

--- a/typescript/deploy-ids.ts
+++ b/typescript/deploy-ids.ts
@@ -13,6 +13,7 @@ export const PENDLE_PT_AUSDC_DECIMAL_CONVERTER_ID = "ChainlinkDecimalConverter_P
 export const PENDLE_PT_WSTKSCUSD_DECIMAL_CONVERTER_ID = "ChainlinkDecimalConverter_PT_wstkscUSD_18DEC2025";
 export const OS_TO_S_DECIMAL_CONVERTER_ID = "ChainlinkDecimalConverter_OS_to_S";
 export const WOS_TO_OS_DECIMAL_CONVERTER_ID = "ChainlinkDecimalConverter_wOS_to_OS";
+export const SFRXUSD_UPSCALE_DECIMAL_CONVERTER_ID = "ChainlinkDecimalConverterV2_sfrxUSD_Upscale";
 
 // S Oracles
 export const S_ORACLE_AGGREGATOR_ID = "S_OracleAggregator";


### PR DESCRIPTION
- Support both Chainlink legacy and current price feed.
- Support both downscale and upscale decimals.